### PR TITLE
barnacles: authd

### DIFF
--- a/authd.ru
+++ b/authd.ru
@@ -1,0 +1,33 @@
+require ::File.expand_path('../config/environment',  __FILE__)
+require 'rack/reverse_proxy'
+
+class Authd
+  def initialize
+    config = Rails.application.config
+    key_generator = ActiveSupport::KeyGenerator.new(config.secret_key_base, iterations: 1000)
+    secret = key_generator.generate_key(config.action_dispatch.encrypted_cookie_salt)
+    sign_secret = key_generator.generate_key(config.action_dispatch.encrypted_signed_cookie_salt)
+    @encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret)
+    @yxorp = Rack::ReverseProxy.new do
+      reverse_proxy(//, 'http://localhost:9000')
+    end
+  end
+
+  def maybe_db_session_token_of(data)
+    @encryptor.decrypt_and_verify(data)['u']
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage
+    nil
+  end
+
+  def call(env)
+    request = ActionDispatch::Request.new(env)
+    data = request.cookie_jar['lobster_trap']
+    maybe = Authd.new.maybe_db_session_token_of(data)
+    if maybe
+      env['HTTP_X_FROM_AUTHD'] = maybe
+    end
+    @yxorp.call(env)
+  end
+end
+
+run Authd.new


### PR DESCRIPTION
An authentication HTTP server that does the insane Rails PBKDF2-then-verify-then-decrypt, which by the way is named `decrypt_and_verify` (which makes it sound like it's doing decryption and THEN verifcation, which makes your heart stop a little bit until you read the source code), and then reverse-proxies the actual data we want onto a yet-to-be-determined-but-hopefully-Haskell backend.

This data takes the form of the `session_token` stored alongside the user's row in the `users` table.

We could do this authentication and decryption ourselves in Haskell, but the OpenSSL bindings are poor, and there's no way to shell out to `openssl(1)` for, at least, and at least that I could find, PBKDF2.

To test this, run `./bin/thin -R authd.ru start`. You'll need some sort of dummy HTTP server running on port 9000 localhost, or you can modify the source code and have it point at something else, like requestbin.
